### PR TITLE
JOSS paper copy edits

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -51,7 +51,7 @@
 
 @article{weinberg2017,
  author = {Weinberg, Phillip and Bukov, Marin},
- title = {{QuSpin:} {A} Python package for dynamics and exact diagonalisation of quantum many body systems part I: {Spin} chains},
+ title = {{QuSpin:} {A} {Python} package for dynamics and exact diagonalisation of quantum many body systems part {I}: {Spin} chains},
  journal = {SciPost Phys.},
  volume = {2},
  issue = {1},
@@ -100,14 +100,18 @@
 @article{astrakhantsev2021,
  author = {Astrakhantsev, Nikita and Westerhout, Tom and Tiwari, Apoorv and Choo, Kenny and Chen, Ao and Fischer, Mark H and Carleo, Giuseppe and Neupert, Titus},
  title = {Broken-Symmetry Ground States of the {Heisenberg} model on the Pyrochlore Lattice},
- journal = {arXiv preprint arXiv:2101.08787},
+ journal = {arXiv Condensed Matter},
+ archivePrefix={arXiv},
+ eprint={2101.08787},
  year = {2021},
 }
 
 @article{bagrov2020,
  author = {Bagrov, Andrey A and Iliasov, Askar A and Westerhout, Tom},
  title = {Kinetic samplers for neural quantum states},
- journal = {arXiv preprint arXiv:2011.02986},
+ journal = {arXiv Condensed Matter},
+ archivePrefix={arXiv},
+ eprint={2011.02986},
  year = {2020},
 }
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -27,19 +27,19 @@ Exact diagonalization (ED) is one of the most reliable and established numerical
 methods of quantum many-body theory. It is precise, unbiased, and general
 enough to be applicable to a huge variety of problems in condensed matter
 physics. Mathematically, ED is a linear algebra problem involving a matrix
-called Hamiltonian. For a system of spin-1/2 particles, the size of this matrix
+called the Hamiltonian. For a system of spin-1/2 particles, the size of this matrix
 scales exponentially (as $\mathcal{O}(2^N)$) with the number of particles $N$.
 
 Very fast scaling of memory requirements with system size is the main
 computational challenge of the method. There are a few techniques allowing one
 to lower the amount of storage used by the Hamiltonian. For example, one can
 store only the non-zero elements of the Hamiltonian. This is beneficial when the
-Hamiltonian is sparse which is usually the case in condensed matter physics.
+Hamiltonian is sparse, which is usually the case in condensed matter physics.
 One can even take it one step further and avoid storing the matrix altogether by
 instead computing matrix elements on the fly.
 
 A complementary approach to reduce memory requirements is to make use of system
-symmetries. For example, many relevant Hamiltonians possess $U(1)$ symmetry
+symmetries. For example, many relevant Hamiltonians possess $U(1)$ symmetry,
 which permits one to perform calculations assuming that the number of particles
 (or number of spins pointing upwards), is fixed. Another example would be
 translational invariance of the underlying lattice.
@@ -51,27 +51,27 @@ realization of these algorithms. Instead of writing their own optimized
 implementation for every system of interest, a domain expert provides
 system-specific details (such as the number of particles or momentum quantum
 number) to `lattice-symmetries` and it will automatically construct a reduced
-Hamiltonian. Dimension of the new Hamiltonian can be multiple orders of
+Hamiltonian. The dimension of the new Hamiltonian can be multiple orders of
 magnitude smaller than of the original one.
 
 Furthermore, in `lattice-symmetries` the Hamiltonian itself is never stored.
-Instead, its matrix elements are computed on the fly which reduces the memory
+Instead, its matrix elements are computed on the fly, which reduces the memory
 requirements even more. Care is taken to keep the implementation generic such
 that different physical systems can be studied, but without sacrificing
 performance as we will show in the next section.
 
 All in all, `lattice-symmetries` serves as a foundation for building
 state-of-the-art ED and VMC (Variational Monte Carlo) applications. For example,
-`SpinED` [@SpinED] is an easy-to-use application for exact diagonalization which
+`SpinED` [@SpinED] is an easy-to-use application for exact diagonalization that
 is built on top of `lattice-symmetries` and can handle clusters of at least
 42 spins on a single node.
 
 # Statement of need
 
 Exact diagonalization is an old and well-established method and many packages
-have been written for it. However, we find that for some reason most
+have been written for it. However, we find that most
 state-of-the-art implementations [@wietek2018; @lauchi2019] are closed-source.
-There are but three notable open-source projects which natively support spin
+There are but three notable open-source projects that natively support spin
 systems[^1] : $\text{H}\Phi$ [@kawamura2017], `SPINPACK` [@schulenburg2017], and
 `QuSpin` [@weinberg2017].
 
@@ -81,10 +81,10 @@ systems[^1] : $\text{H}\Phi$ [@kawamura2017], `SPINPACK` [@schulenburg2017], and
   symmetries are lost in the new Hamiltonian.
 
 ![Performance of matrix-vector products in `QuSpin`, `SPINPACK`, and
-`lattice-symmetries`. For Heisenberg Hamiltonian on square lattices of different
+`lattice-symmetries`. For a Heisenberg Hamiltonian on square lattices of different
 sizes, we measure the time it takes to do a single matrix-vector product.
 Timings for `lattice-symmetries` are normalized to $1$ to show relative speedup
-compared to `QuSpin`, but for reference absolute times in seconds are listed as
+compared to `QuSpin`, with absolute times in seconds listed as
 well. Depending on the system speedups over `QuSpin` vary between 5 and 22
 times, but in all cases `lattice-symmetries` is significantly faster.
 \label{fig:performance}](02_operator_application.jpg){ width=90% }
@@ -94,17 +94,17 @@ finite temperatures, and supports multi-node computations. However, there are a
 few points in which `lattice-symmetries` improves upon $\text{H}\Phi$. Firstly,
 $\text{H}\Phi$ does not support arbitrary lattice symmetries. Secondly, it uses
 a custom input file format making it not user-friendly. Finally, since
-$\text{H}\Phi$ is an executable, it cannot be used to develop new algorithms.
+$\text{H}\Phi$ is an executable, it cannot be used to as a library to develop new algorithms and applications.
 
 `SPINPACK` is another popular solution for diagonalization of spin Hamiltonians.
-`SPINPACK` does support user-defined symmetries as opposed to $\text{H}\Phi$,
+`SPINPACK` does support user-defined symmetries, unlike $\text{H}\Phi$,
 but its interface is even less user-friendly. Defining a lattice, Hamiltonian,
 and symmetries requires writing non-trivial amounts of `C` code. Finally,
 `SPINPACK` is slower than `lattice-symmetries` as illustrated in
 \autoref{fig:performance}.
 
 `QuSpin` is much closer in functionality to `lattice-symmetries`. It is a high-level
-Python package which natively supports (but is not limited to) spin systems, can
+Python package, which natively supports (but is not limited to) spin systems, can
 employ user-defined lattice symmetries, and can also perform matrix-free
 calculations (where matrix elements are computed on the fly). However, `QuSpin`
 mostly focuses on ease of use and functionality rather than performance. In
@@ -114,9 +114,9 @@ algorithms as `QuSpin`, careful implementation allows us to achieve an order of
 magnitude speedup as shown in \autoref{fig:performance}. To achieve such
 performance, we make heavy use of Single Instruction Multiple Data (SIMD)
 instructions supported by modern processors. Vector Class Library [@vectorclass]
-is used to write all performance-critical kernels which currently limits the
+is used to write all performance-critical kernels, which currently limits the
 portability of `lattice-symmetries` to processors supporting `x86-64` instruction
-set [@amd1999].
+sets [@amd1999].
 
 `lattice-symmetries` is a library implemented in `C++` and `C`. It provides two
 interfaces:
@@ -127,7 +127,7 @@ interfaces:
   * A higher-level `Python` wrapper which allows to easily test and prototype
   algorithms.
 
-We make the library easily installable via `Conda` package manager.
+The library is easily installable via the `Conda` package manager.
 
 The general workflow is as follows: the user starts by defining a few symmetry
 generators (`ls_symmetry`/`Symmetry` in `C`/`Python`) from which
@@ -138,14 +138,13 @@ applications functionality provided by `SpinBasis` may be sufficient, but
 typically the user will construct one (or multiple) quantum mechanical operators
 (`ls_operator`/`Operator` in `C`/`Python`) corresponding to the Hamiltonian and
 various observables. `lattice-symmetries` supports generic 1-, 2-, 3-, and
-4-point operators. Examples of Hamiltonians which can be constructed, include
+4-point operators. Examples of Hamiltonians that can be constructed include
 
 $$
 \begin{aligned}
-    H &= \sum_{i, j} J_{ij} \boldsymbol\sigma_i \cdot \boldsymbol\sigma_j \,,\;\text{--- Heisenberg interaction,} \\
-    H &= \sum_{i, j} J_{ij} \sigma^z_i \sigma^z_j + \sum_i h_i \sigma^x_i \,,\;\text{--- Ising model in transverse magnetic field,} \\
-    H &= \sum_{i, j} \mathbf{D}_{ij} \left[ \boldsymbol\sigma_i \times \boldsymbol\sigma_j \right] \,,\;\text{--- Dzyaloshinskii-Moriya interaction,} \\
-    &\dots
+    H &= \sum_{i, j} J_{ij} \boldsymbol\sigma_i \cdot \boldsymbol\sigma_j && \text{Heisenberg interaction,} \\
+    H &= \sum_{i, j} J_{ij} \sigma^z_i \sigma^z_j + \sum_i h_i \sigma^x_i && \text{Ising model in transverse magnetic field,} \\
+    H &= \sum_{i, j} \mathbf{D}_{ij} \left[ \boldsymbol\sigma_i \times \boldsymbol\sigma_j \right] && \text{Dzyaloshinskii-Moriya interaction.} \\
 \end{aligned}
 $$
 
@@ -153,25 +152,23 @@ Here, $\boldsymbol\sigma$ denotes Pauli matrices, $J$ and $\mathbf{D}$ are
 various coupling constants, and sums over $i$ and $j$ can run over arbitrary
 used-defined geometries.
 
-`Operator` can be efficiently applied to vectors in the Hilbert space (i.e.
+`Operator`s can be efficiently applied to vectors in the Hilbert space (i.e.,
 wavefunctions). Also, in cases when the Hilbert space dimension is so big that
 the wavefunction cannot be written down explicitly (as a list of coefficients),
 `Operator` can be applied to individual spin configurations to implement Monte
 Carlo local estimators.
 
 As an example of what can be done with `lattice-symmetries`, we implemented a
-standalone application for exact diagonalization studies of spin-1/2 systems:
-`SpinED`. By combining `lattice-symmetries` with PRIMME eigensolver
+standalone application for exact diagonalization studies of spin-1/2 systems,
+`SpinED`. By combining `lattice-symmetries` with the PRIMME eigensolver
 [@stathopoulos2010], it allows one to treat systems of at least 42
 sites on a single node. `SpinED` is distributed as a statically-linked
 executable --- one can download one file and immediately get started with
 physics. All in all, it makes large-scale ED more approachable for non-experts.
 
-Finally, we would like to note that `lattice-symmetries` and `SpinED` have
-already been used in a number of research projects [@astrakhantsev2021;
-@bagrov2020; @westerhout2020], and we feel that they could benefit many more.
-For example, `lattice-symmetries` is currently even being used to simulate
-quantum circuits [@qsl2021].
+Notable research projects using `lattice-symmetries` and `SpinED` include @astrakhantsev2021,
+@bagrov2020, and @westerhout2020.
+Additionally, `lattice-symmetries` is being used to simulate quantum circuits [@qsl2021].
 
 # Acknowledgements
 


### PR DESCRIPTION
This fixes a few issues and I made some minor suggestions that I think improve the flow. (See commit messages.) Still remaining:

- [ ] JOSS uses APA style so all journal names should be written in full, not abbreviated.

Cc: https://github.com/openjournals/joss-reviews/issues/3537